### PR TITLE
Allow registering SchemaProviders via the QueryContextBuilder

### DIFF
--- a/core/api/src/main/java/com/blazebit/query/spi/QueryContextBuilder.java
+++ b/core/api/src/main/java/com/blazebit/query/spi/QueryContextBuilder.java
@@ -77,6 +77,14 @@ public interface QueryContextBuilder {
     <T> QueryContextBuilder registerSchemaObject(Class<T> schemaObjectType, DataFetcher<T> dataFetcher);
 
     /**
+     * Registers a {@link QuerySchemaProvider} to provide schema objects.
+     *
+     * @param querySchemaProvider The {@link QuerySchemaProvider} to register
+     * @return The updated {@link QueryContextBuilder} object
+     */
+    QueryContextBuilder registerSchemaProvider(QuerySchemaProvider querySchemaProvider);
+
+    /**
      * Loads the available services through the Java {@link java.util.ServiceLoader} API.
      *
      * @return {@code this} object for method chaining

--- a/core/impl/src/main/java/com/blazebit/query/impl/QueryContextBuilderImpl.java
+++ b/core/impl/src/main/java/com/blazebit/query/impl/QueryContextBuilderImpl.java
@@ -65,9 +65,15 @@ public class QueryContextBuilderImpl implements QueryContextBuilder {
     }
 
     @Override
+    public QueryContextBuilder registerSchemaProvider(QuerySchemaProvider querySchemaProvider) {
+        schemaProviders.add(querySchemaProvider);
+        return this;
+    }
+
+    @Override
     public QueryContextBuilder loadServices() {
         for ( QuerySchemaProvider querySchemaProvider : ServiceLoader.load( QuerySchemaProvider.class ) ) {
-            schemaProviders.add( querySchemaProvider );
+            registerSchemaProvider(querySchemaProvider);
         }
         return this;
     }


### PR DESCRIPTION
Allow registering SchemaProviders via the QueryContextBuilder. This is especially useful for unit testing where it allows creating a concise QueryContext. In the current implementation, the ServiceLoader loads all SchemaProviders on the classpath, which means that more properties need to be configured than required for a unit test.