### PR TITLE
AWS MFA devices datafetcher and account summary datafetchers

### DIFF
--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummary.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummary.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * @since 1.0.0
  */
 public class AccountSummary {
-    // Create getters, setters and constructor for the following fields
+
     private int groupPolicySizeQuota;
     private int instanceProfilesQuota;
     private int policies;

--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummary.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummary.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2024 - 2024 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.query.connector.aws.iam;
+
+import software.amazon.awssdk.services.iam.model.SummaryKeyType;
+
+import java.util.Map;
+
+/**
+ * @author Martijn Sprengers
+ * @since 1.0.0
+ */
+public class AccountSummary {
+    // Create getters, setters and constructor for the following fields
+    private int groupPolicySizeQuota;
+    private int instanceProfilesQuota;
+    private int policies;
+    private int groupsPerUserQuota;
+    private int instanceProfiles;
+    private int attachedPoliciesPerUserQuota;
+    private int users;
+    private int policiesQuota;
+    private int providers;
+    private int accountMFAEnabled;
+    private int accessKeysPerUserQuota;
+    private int assumeRolePolicySizeQuota;
+    private int policyVersionsInUseQuota;
+    private int globalEndpointTokenVersion;
+    private int versionsPerPolicyQuota;
+    private int attachedPoliciesPerGroupQuota;
+    private int policySizeQuota;
+    private int groups;
+    private int accountSigningCertificatesPresent;
+    private int usersQuota;
+    private int serverCertificatesQuota;
+    private int mfaDevices;
+    private int userPolicySizeQuota;
+    private int policyVersionsInUse;
+    private int serverCertificates;
+    private int roles;
+    private int rolesQuota;
+    private int signingCertificatesPerUserQuota;
+    private int mfaDevicesInUse;
+    private int rolePolicySizeQuota;
+    private int attachedPoliciesPerRoleQuota;
+    private int accountAccessKeysPresent;
+    private int accountPasswordPresent;
+    private int groupsQuota;
+
+
+
+    public AccountSummary(Map<SummaryKeyType, Integer> summaryKeyTypeIntegerMap) {
+        this.groupPolicySizeQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.GROUP_POLICY_SIZE_QUOTA);
+        this.policies = summaryKeyTypeIntegerMap.get(SummaryKeyType.POLICIES);
+        this.groupsPerUserQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.GROUPS_PER_USER_QUOTA);
+        this.attachedPoliciesPerUserQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.ATTACHED_POLICIES_PER_USER_QUOTA);
+        this.users = summaryKeyTypeIntegerMap.get(SummaryKeyType.USERS);
+        this.policiesQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.POLICIES_QUOTA);
+        this.accountMFAEnabled = summaryKeyTypeIntegerMap.get(SummaryKeyType.ACCOUNT_MFA_ENABLED);
+        this.accessKeysPerUserQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.ACCESS_KEYS_PER_USER_QUOTA);
+        this.policyVersionsInUseQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.POLICY_VERSIONS_IN_USE_QUOTA);
+        this.globalEndpointTokenVersion = summaryKeyTypeIntegerMap.get(SummaryKeyType.GLOBAL_ENDPOINT_TOKEN_VERSION);
+        this.versionsPerPolicyQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.VERSIONS_PER_POLICY_QUOTA);
+        this.attachedPoliciesPerGroupQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.ATTACHED_POLICIES_PER_GROUP_QUOTA);
+        this.policySizeQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.POLICY_SIZE_QUOTA);
+        this.groups = summaryKeyTypeIntegerMap.get(SummaryKeyType.GROUPS);
+        this.accountSigningCertificatesPresent = summaryKeyTypeIntegerMap.get(SummaryKeyType.ACCOUNT_SIGNING_CERTIFICATES_PRESENT);
+        this.usersQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.USERS_QUOTA);
+        this.serverCertificatesQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.SERVER_CERTIFICATES_QUOTA);
+        this.mfaDevices = summaryKeyTypeIntegerMap.get(SummaryKeyType.MFA_DEVICES);
+        this.userPolicySizeQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.USER_POLICY_SIZE_QUOTA);
+        this.policyVersionsInUse = summaryKeyTypeIntegerMap.get(SummaryKeyType.POLICY_VERSIONS_IN_USE);
+        this.serverCertificates = summaryKeyTypeIntegerMap.get(SummaryKeyType.SERVER_CERTIFICATES);
+        this.signingCertificatesPerUserQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.SIGNING_CERTIFICATES_PER_USER_QUOTA);
+        this.mfaDevicesInUse = summaryKeyTypeIntegerMap.get(SummaryKeyType.MFA_DEVICES_IN_USE);
+        this.attachedPoliciesPerRoleQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.ATTACHED_POLICIES_PER_ROLE_QUOTA);
+        this.accountAccessKeysPresent = summaryKeyTypeIntegerMap.get(SummaryKeyType.ACCOUNT_ACCESS_KEYS_PRESENT);
+        this.groupsQuota = summaryKeyTypeIntegerMap.get(SummaryKeyType.GROUPS_QUOTA);
+    }
+
+    public int getGroupPolicySizeQuota() {
+        return groupPolicySizeQuota;
+    }
+
+    public void setGroupPolicySizeQuota(int groupPolicySizeQuota) {
+        this.groupPolicySizeQuota = groupPolicySizeQuota;
+    }
+
+    public int getInstanceProfilesQuota() {
+        return instanceProfilesQuota;
+    }
+
+    public void setInstanceProfilesQuota(int instanceProfilesQuota) {
+        this.instanceProfilesQuota = instanceProfilesQuota;
+    }
+
+    public int getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(int policies) {
+        this.policies = policies;
+    }
+
+    public int getGroupsPerUserQuota() {
+        return groupsPerUserQuota;
+    }
+
+    public void setGroupsPerUserQuota(int groupsPerUserQuota) {
+        this.groupsPerUserQuota = groupsPerUserQuota;
+    }
+
+    public int getInstanceProfiles() {
+        return instanceProfiles;
+    }
+
+    public void setInstanceProfiles(int instanceProfiles) {
+        this.instanceProfiles = instanceProfiles;
+    }
+
+    public int getAttachedPoliciesPerUserQuota() {
+        return attachedPoliciesPerUserQuota;
+    }
+
+    public void setAttachedPoliciesPerUserQuota(int attachedPoliciesPerUserQuota) {
+        this.attachedPoliciesPerUserQuota = attachedPoliciesPerUserQuota;
+    }
+
+    public int getUsers() {
+        return users;
+    }
+
+    public void setUsers(int users) {
+        this.users = users;
+    }
+
+    public int getPoliciesQuota() {
+        return policiesQuota;
+    }
+
+    public void setPoliciesQuota(int policiesQuota) {
+        this.policiesQuota = policiesQuota;
+    }
+
+    public int getProviders() {
+        return providers;
+    }
+
+    public void setProviders(int providers) {
+        this.providers = providers;
+    }
+
+    public int getAccountMFAEnabled() {
+        return accountMFAEnabled;
+    }
+
+    public void setAccountMFAEnabled(int accountMFAEnabled) {
+        this.accountMFAEnabled = accountMFAEnabled;
+    }
+
+    public int getAccessKeysPerUserQuota() {
+        return accessKeysPerUserQuota;
+    }
+
+    public void setAccessKeysPerUserQuota(int accessKeysPerUserQuota) {
+        this.accessKeysPerUserQuota = accessKeysPerUserQuota;
+    }
+
+    public int getAssumeRolePolicySizeQuota() {
+        return assumeRolePolicySizeQuota;
+    }
+
+    public void setAssumeRolePolicySizeQuota(int assumeRolePolicySizeQuota) {
+        this.assumeRolePolicySizeQuota = assumeRolePolicySizeQuota;
+    }
+
+    public int getPolicyVersionsInUseQuota() {
+        return policyVersionsInUseQuota;
+    }
+
+    public void setPolicyVersionsInUseQuota(int policyVersionsInUseQuota) {
+        this.policyVersionsInUseQuota = policyVersionsInUseQuota;
+    }
+
+    public int getGlobalEndpointTokenVersion() {
+        return globalEndpointTokenVersion;
+    }
+
+    public void setGlobalEndpointTokenVersion(int globalEndpointTokenVersion) {
+        this.globalEndpointTokenVersion = globalEndpointTokenVersion;
+    }
+
+    public int getVersionsPerPolicyQuota() {
+        return versionsPerPolicyQuota;
+    }
+
+    public void setVersionsPerPolicyQuota(int versionsPerPolicyQuota) {
+        this.versionsPerPolicyQuota = versionsPerPolicyQuota;
+    }
+
+    public int getAttachedPoliciesPerGroupQuota() {
+        return attachedPoliciesPerGroupQuota;
+    }
+
+    public void setAttachedPoliciesPerGroupQuota(int attachedPoliciesPerGroupQuota) {
+        this.attachedPoliciesPerGroupQuota = attachedPoliciesPerGroupQuota;
+    }
+
+    public int getPolicySizeQuota() {
+        return policySizeQuota;
+    }
+
+    public void setPolicySizeQuota(int policySizeQuota) {
+        this.policySizeQuota = policySizeQuota;
+    }
+
+    public int getGroups() {
+        return groups;
+    }
+
+    public void setGroups(int groups) {
+        this.groups = groups;
+    }
+
+    public int getAccountSigningCertificatesPresent() {
+        return accountSigningCertificatesPresent;
+    }
+
+    public void setAccountSigningCertificatesPresent(int accountSigningCertificatesPresent) {
+        this.accountSigningCertificatesPresent = accountSigningCertificatesPresent;
+    }
+
+    public int getUsersQuota() {
+        return usersQuota;
+    }
+
+    public void setUsersQuota(int usersQuota) {
+        this.usersQuota = usersQuota;
+    }
+
+    public int getServerCertificatesQuota() {
+        return serverCertificatesQuota;
+    }
+
+    public void setServerCertificatesQuota(int serverCertificatesQuota) {
+        this.serverCertificatesQuota = serverCertificatesQuota;
+    }
+
+    public int getMfaDevices() {
+        return mfaDevices;
+    }
+
+    public void setMfaDevices(int mfaDevices) {
+        this.mfaDevices = mfaDevices;
+    }
+
+    public int getUserPolicySizeQuota() {
+        return userPolicySizeQuota;
+    }
+
+    public void setUserPolicySizeQuota(int userPolicySizeQuota) {
+        this.userPolicySizeQuota = userPolicySizeQuota;
+    }
+
+    public int getPolicyVersionsInUse() {
+        return policyVersionsInUse;
+    }
+
+    public void setPolicyVersionsInUse(int policyVersionsInUse) {
+        this.policyVersionsInUse = policyVersionsInUse;
+    }
+
+    public int getServerCertificates() {
+        return serverCertificates;
+    }
+
+    public void setServerCertificates(int serverCertificates) {
+        this.serverCertificates = serverCertificates;
+    }
+
+    public int getRoles() {
+        return roles;
+    }
+
+    public void setRoles(int roles) {
+        this.roles = roles;
+    }
+
+    public int getRolesQuota() {
+        return rolesQuota;
+    }
+
+    public void setRolesQuota(int rolesQuota) {
+        this.rolesQuota = rolesQuota;
+    }
+
+    public int getSigningCertificatesPerUserQuota() {
+        return signingCertificatesPerUserQuota;
+    }
+
+    public void setSigningCertificatesPerUserQuota(int signingCertificatesPerUserQuota) {
+        this.signingCertificatesPerUserQuota = signingCertificatesPerUserQuota;
+    }
+
+    public int getMfaDevicesInUse() {
+        return mfaDevicesInUse;
+    }
+
+    public void setMfaDevicesInUse(int mfaDevicesInUse) {
+        this.mfaDevicesInUse = mfaDevicesInUse;
+    }
+
+    public int getRolePolicySizeQuota() {
+        return rolePolicySizeQuota;
+    }
+
+    public void setRolePolicySizeQuota(int rolePolicySizeQuota) {
+        this.rolePolicySizeQuota = rolePolicySizeQuota;
+    }
+
+    public int getAttachedPoliciesPerRoleQuota() {
+        return attachedPoliciesPerRoleQuota;
+    }
+
+    public void setAttachedPoliciesPerRoleQuota(int attachedPoliciesPerRoleQuota) {
+        this.attachedPoliciesPerRoleQuota = attachedPoliciesPerRoleQuota;
+    }
+
+    public int getAccountAccessKeysPresent() {
+        return accountAccessKeysPresent;
+    }
+
+    public void setAccountAccessKeysPresent(int accountAccessKeysPresent) {
+        this.accountAccessKeysPresent = accountAccessKeysPresent;
+    }
+
+    public int getAccountPasswordPresent() {
+        return accountPasswordPresent;
+    }
+
+    public void setAccountPasswordPresent(int accountPasswordPresent) {
+        this.accountPasswordPresent = accountPasswordPresent;
+    }
+
+    public int getGroupsQuota() {
+        return groupsQuota;
+    }
+
+    public void setGroupsQuota(int groupsQuota) {
+        this.groupsQuota = groupsQuota;
+    }
+}

--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummaryDataFetcher.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummaryDataFetcher.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 - 2024 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.query.connector.aws.iam;
+
+import com.blazebit.query.connector.aws.base.AwsConnectorConfig;
+import com.blazebit.query.connector.aws.base.AwsConventionContext;
+import com.blazebit.query.connector.base.DataFormats;
+import com.blazebit.query.spi.DataFetchContext;
+import com.blazebit.query.spi.DataFetcher;
+import com.blazebit.query.spi.DataFetcherException;
+import com.blazebit.query.spi.DataFormat;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.IamClientBuilder;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Martijn Sprengers
+ * @since 1.0.0
+ */
+public class AccountSummaryDataFetcher implements DataFetcher<AccountSummary>, Serializable {
+
+    public static final AccountSummaryDataFetcher INSTANCE = new AccountSummaryDataFetcher();
+
+    private AccountSummaryDataFetcher() {
+    }
+
+    @Override
+    public DataFormat getDataFormat() {
+        return DataFormats.componentMethodConvention(AccountSummary.class, AwsConventionContext.INSTANCE);
+    }
+
+    @Override
+    public List<AccountSummary> fetch(DataFetchContext context) {
+        try {
+            List<AwsConnectorConfig.Account> accounts = AwsConnectorConfig.ACCOUNT.getAll( context );
+            SdkHttpClient sdkHttpClient = AwsConnectorConfig.HTTP_CLIENT.find( context );
+            List<AccountSummary> list = new ArrayList<>();
+            for ( AwsConnectorConfig.Account account : accounts) {
+                IamClientBuilder ec2ClientBuilder = IamClient.builder()
+                        .region( account.getRegion() )
+                        .credentialsProvider( account.getCredentialsProvider() );
+                if ( sdkHttpClient != null ) {
+                    ec2ClientBuilder.httpClient( sdkHttpClient );
+                }
+                try (IamClient client = ec2ClientBuilder.build()) {
+                    list.add(new AccountSummary(client.getAccountSummary().summaryMap()));
+                }
+            }
+            return list;
+        } catch (RuntimeException e) {
+            throw new DataFetcherException("Could not fetch user list", e);
+        }
+    }
+}

--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummaryDataFetcher.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummaryDataFetcher.java
@@ -66,7 +66,7 @@ public class AccountSummaryDataFetcher implements DataFetcher<AccountSummary>, S
             }
             return list;
         } catch (RuntimeException e) {
-            throw new DataFetcherException("Could not fetch user list", e);
+            throw new DataFetcherException("Could not fetch account summary", e);
         }
     }
 }

--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AwsIAMSchemaProvider.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AwsIAMSchemaProvider.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.blazebit.query.spi.ConfigurationProvider;
 import com.blazebit.query.spi.DataFetcher;
 import com.blazebit.query.spi.QuerySchemaProvider;
+import software.amazon.awssdk.services.iam.model.MFADevice;
 import software.amazon.awssdk.services.iam.model.User;
 
 /**
@@ -39,7 +40,9 @@ public final class AwsIAMSchemaProvider implements QuerySchemaProvider {
     @Override
     public Map<Class<?>, ? extends DataFetcher<?>> resolveSchemaObjects(ConfigurationProvider configurationProvider) {
         return Map.<Class<?>, DataFetcher<?>>of(
-                User.class, UserDataFetcher.INSTANCE
+                User.class, UserDataFetcher.INSTANCE,
+                MFADevice.class, MFADeviceDataFetcher.INSTANCE,
+                AccountSummary.class, AccountSummaryDataFetcher.INSTANCE
         );
     }
 }

--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/MFADeviceDataFetcher.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/MFADeviceDataFetcher.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 - 2024 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.query.connector.aws.iam;
+
+import com.blazebit.query.connector.aws.base.AwsConnectorConfig;
+import com.blazebit.query.connector.aws.base.AwsConventionContext;
+import com.blazebit.query.connector.base.DataFormats;
+import com.blazebit.query.spi.DataFetchContext;
+import com.blazebit.query.spi.DataFetcher;
+import com.blazebit.query.spi.DataFetcherException;
+import com.blazebit.query.spi.DataFormat;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.IamClientBuilder;
+import software.amazon.awssdk.services.iam.model.MFADevice;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Martijn Sprengers
+ * @since 1.0.0
+ */
+public class MFADeviceDataFetcher implements DataFetcher<MFADevice>, Serializable {
+
+    public static final MFADeviceDataFetcher INSTANCE = new MFADeviceDataFetcher();
+
+    private MFADeviceDataFetcher() {
+    }
+
+    @Override
+    public DataFormat getDataFormat() {
+        return DataFormats.componentMethodConvention(MFADevice.class, AwsConventionContext.INSTANCE);
+    }
+
+    @Override
+    public List<MFADevice> fetch(DataFetchContext context) {
+        try {
+            List<AwsConnectorConfig.Account> accounts = AwsConnectorConfig.ACCOUNT.getAll( context );
+            SdkHttpClient sdkHttpClient = AwsConnectorConfig.HTTP_CLIENT.find( context );
+            List<MFADevice> list = new ArrayList<>();
+            for ( AwsConnectorConfig.Account account : accounts) {
+                IamClientBuilder ec2ClientBuilder = IamClient.builder()
+                        .region( account.getRegion() )
+                        .credentialsProvider( account.getCredentialsProvider() );
+                if ( sdkHttpClient != null ) {
+                    ec2ClientBuilder.httpClient( sdkHttpClient );
+                }
+                try (IamClient client = ec2ClientBuilder.build()) {
+                    list.addAll( client.listMFADevices().mfaDevices() );
+                }
+            }
+            return list;
+        } catch (RuntimeException e) {
+            throw new DataFetcherException("Could not fetch MFA devices list", e);
+        }
+    }
+}


### PR DESCRIPTION
To retrieve AWS IAM configurations that deal with Multi-Factor Authentication, two data fetchers are required:
1. MFADevices: Retrieves all devices that have been configured for MFA;
2. Account Summary: Retrieves the summary of settings for an AWS account, which contains an `int` (`AccountMFAEnabled`) that indicates if the AWS root account has MFA enabled.