### PR TITLE
Fix: Mfa devices per user

### DIFF
--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummaryDataFetcher.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/AccountSummaryDataFetcher.java
@@ -54,13 +54,13 @@ public class AccountSummaryDataFetcher implements DataFetcher<AccountSummary>, S
             SdkHttpClient sdkHttpClient = AwsConnectorConfig.HTTP_CLIENT.find( context );
             List<AccountSummary> list = new ArrayList<>();
             for ( AwsConnectorConfig.Account account : accounts) {
-                IamClientBuilder ec2ClientBuilder = IamClient.builder()
+                IamClientBuilder iamClientBuilder = IamClient.builder()
                         .region( account.getRegion() )
                         .credentialsProvider( account.getCredentialsProvider() );
                 if ( sdkHttpClient != null ) {
-                    ec2ClientBuilder.httpClient( sdkHttpClient );
+                    iamClientBuilder.httpClient( sdkHttpClient );
                 }
-                try (IamClient client = ec2ClientBuilder.build()) {
+                try (IamClient client = iamClientBuilder.build()) {
                     list.add(new AccountSummary(client.getAccountSummary().summaryMap()));
                 }
             }

--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/MFADeviceDataFetcher.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/MFADeviceDataFetcher.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.IamClientBuilder;
 import software.amazon.awssdk.services.iam.model.MFADevice;
+import software.amazon.awssdk.services.iam.model.User;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -62,7 +63,9 @@ public class MFADeviceDataFetcher implements DataFetcher<MFADevice>, Serializabl
                     iamClientBuilder.httpClient( sdkHttpClient );
                 }
                 try (IamClient client = iamClientBuilder.build()) {
-                    list.addAll( client.listMFADevices().mfaDevices() );
+                    for (User user : context.getSession().get(User.class)) {
+                        list.addAll( client.listMFADevices(builder -> builder.userName(user.userName())).mfaDevices() );
+                    }
                 }
             }
             return list;

--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/MFADeviceDataFetcher.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/MFADeviceDataFetcher.java
@@ -55,13 +55,13 @@ public class MFADeviceDataFetcher implements DataFetcher<MFADevice>, Serializabl
             SdkHttpClient sdkHttpClient = AwsConnectorConfig.HTTP_CLIENT.find( context );
             List<MFADevice> list = new ArrayList<>();
             for ( AwsConnectorConfig.Account account : accounts) {
-                IamClientBuilder ec2ClientBuilder = IamClient.builder()
+                IamClientBuilder iamClientBuilder = IamClient.builder()
                         .region( account.getRegion() )
                         .credentialsProvider( account.getCredentialsProvider() );
                 if ( sdkHttpClient != null ) {
-                    ec2ClientBuilder.httpClient( sdkHttpClient );
+                    iamClientBuilder.httpClient( sdkHttpClient );
                 }
-                try (IamClient client = ec2ClientBuilder.build()) {
+                try (IamClient client = iamClientBuilder.build()) {
                     list.addAll( client.listMFADevices().mfaDevices() );
                 }
             }

--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/PasswordPolicyDataFetcher.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/PasswordPolicyDataFetcher.java
@@ -53,13 +53,13 @@ public class PasswordPolicyDataFetcher implements DataFetcher<PasswordPolicy>, S
             SdkHttpClient sdkHttpClient = AwsConnectorConfig.HTTP_CLIENT.find(context);
             List<PasswordPolicy> list = new ArrayList<>();
             for (AwsConnectorConfig.Account account : accounts) {
-                IamClientBuilder ec2ClientBuilder = IamClient.builder()
+                IamClientBuilder iamClientBuilder = IamClient.builder()
                         .region(account.getRegion())
                         .credentialsProvider(account.getCredentialsProvider());
                 if (sdkHttpClient != null) {
-                    ec2ClientBuilder.httpClient(sdkHttpClient);
+                    iamClientBuilder.httpClient(sdkHttpClient);
                 }
-                try (IamClient client = ec2ClientBuilder.build()) {
+                try (IamClient client = iamClientBuilder.build()) {
                     list.add(client.getAccountPasswordPolicy().passwordPolicy());
                 } catch (NoSuchEntityException e) {
                     // The AWS SDK throws a NoSuchEntity exception if the password policy is default

--- a/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/UserDataFetcher.java
+++ b/connector/aws/iam/src/main/java/com/blazebit/query/connector/aws/iam/UserDataFetcher.java
@@ -50,13 +50,13 @@ public class UserDataFetcher implements DataFetcher<User>, Serializable {
             SdkHttpClient sdkHttpClient = AwsConnectorConfig.HTTP_CLIENT.find( context );
             List<User> list = new ArrayList<>();
             for ( AwsConnectorConfig.Account account : accounts) {
-                IamClientBuilder ec2ClientBuilder = IamClient.builder()
+                IamClientBuilder iamClientBuilder = IamClient.builder()
                         .region( account.getRegion() )
                         .credentialsProvider( account.getCredentialsProvider() );
                 if ( sdkHttpClient != null ) {
-                    ec2ClientBuilder.httpClient( sdkHttpClient );
+                    iamClientBuilder.httpClient( sdkHttpClient );
                 }
-                try (IamClient client = ec2ClientBuilder.build()) {
+                try (IamClient client = iamClientBuilder.build()) {
                     list.addAll( client.listUsers().users() );
                 }
             }


### PR DESCRIPTION
When `listMFADevices()` method is called without non-user credentials (e.g. AssumeRole credentials), the following exception is thrown:
```
software.amazon.awssdk.services.iam.model.IamException: Must specify userName when calling with non-User credentials (Service: Iam, Status Code: 400, Request ID: 
```