### PR TITLE
Make it more concrete when a property is not found

### DIFF
--- a/core/api/src/main/java/com/blazebit/query/spi/DataFetcherConfig.java
+++ b/core/api/src/main/java/com/blazebit/query/spi/DataFetcherConfig.java
@@ -76,7 +76,7 @@ public interface DataFetcherConfig<T> {
 	default List<T> getAll(DataFetchContext context) {
 		List<T> value = findAll( context );
 		if ( value.isEmpty() ) {
-			throw new IllegalStateException( "Value for " + this + " required, but not found." );
+			throw new PropertyNotFoundException( "Property for " + this + " required, but not found." );
 		}
 		return value;
 	}

--- a/core/api/src/main/java/com/blazebit/query/spi/PropertyNotFoundException.java
+++ b/core/api/src/main/java/com/blazebit/query/spi/PropertyNotFoundException.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+package com.blazebit.query.spi;
+
+/**
+ * Represents an exception that occurs during fetching of a property from the {@link DataFetchContext}.
+ * This exception can be used to handle errors that occur during data retrieval or processing.
+ *
+ * @author Max Hovens
+ * @since 1.0.0
+ */
+public class PropertyNotFoundException extends RuntimeException {
+
+	/**
+	 * Constructs a new PropertyNotFoundException with the specified detail message.
+	 *
+	 * @param message the detail message
+	 * @throws NullPointerException if the message is null
+	 */
+	public PropertyNotFoundException(String message) {
+		super( message );
+	}
+
+	/**
+	 * Represents an exception that occurs during data fetching. This exception can be used to
+	 * handle errors that occur during data retrieval or processing.
+	 *
+	 * @param message the description of the exception
+	 * @param cause the underlying cause of the exception
+	 */
+	public PropertyNotFoundException(String message, Throwable cause) {
+		super( message, cause );
+	}
+
+	/**
+	 * Constructs a new PropertyNotFoundException with the specified cause.
+	 *
+	 * @param cause the cause of the exception
+	 * @see Throwable#Throwable(Throwable)
+	 */
+	public PropertyNotFoundException(Throwable cause) {
+		super( cause );
+	}
+
+	/**
+	 * Constructs a new PropertyNotFoundException with the specified detail message, cause, suppression
+	 * enabled or disabled, and writable stack trace enabled or disabled.
+	 *
+	 * @param message the detail message (which is saved for later retrieval by the
+	 * getMessage method).
+	 * @param cause the cause (which is saved for later retrieval by the getCause
+	 * method). (A null value is permitted, and indicates that the cause
+	 * is nonexistent or unknown).
+	 * @param enableSuppression whether suppression is enabled or disabled.
+	 * @param writableStackTrace whether the stack trace should be writable.
+	 */
+	public PropertyNotFoundException(
+			String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super( message, cause, enableSuppression, writableStackTrace );
+	}
+}


### PR DESCRIPTION
Make it more concrete when a property is not found with a specific `PropertyNotFoundException`. This enables upstream users to more appropriately handle this case (e.g. when there is no API registered to fetch data from).