### PR TITLE
Do not sign artifacts published to Maven local

### DIFF
--- a/buildSrc/src/main/groovy/blaze-query.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/blaze-query.java-conventions.gradle
@@ -71,6 +71,12 @@ tasks.withType(Javadoc).configureEach {
     failOnError false
 }
 
+tasks.withType(Sign).configureEach {
+    onlyIf("not publishing to local Maven repository") {
+        !gradle.startParameter.taskNames.any { it == 'publishToMavenLocal' }
+    }
+}
+
 tasks.compileJava.dependsOn tasks.spotlessApply
 
 spotless {


### PR DESCRIPTION
With signing enabled, publishing to Maven local is not possible.