### PR TITLE
Add Aws S3 bucket policy fetcher

### DIFF
--- a/connector/aws/s3/build.gradle
+++ b/connector/aws/s3/build.gradle
@@ -11,6 +11,8 @@ plugins {
 dependencies {
     api project(':blaze-query-connector-aws-base')
     api libs.awssdk.s3
+    api libs.jackson.annotations
+    api libs.jackson.databind
     testImplementation libs.junit.jupiter
 }
 

--- a/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/AwsBucketPolicy.java
+++ b/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/AwsBucketPolicy.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+package com.blazebit.query.connector.aws.s3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * @author Donghwi Kim
+ * @since 1.0.0
+ */
+public record AwsBucketPolicy(
+		String accountId,
+		String region,
+		String resourceId,
+		String id,
+		String version,
+		List<AwsBucketPolicyStatement> statement
+) {
+	private static final ObjectMapper MAPPER = ObjectMappers.getInstance();
+
+	public static AwsBucketPolicy fromJson(String accountId, String region, String resourceId, String payload) {
+		try {
+			JsonNode json = MAPPER.readTree( payload );
+			return new AwsBucketPolicy(
+					accountId, region, resourceId, json.has( "Id" ) ? json.get( "Id" ).asText( "" ) : "",
+					json.get( "Version" ).asText( "" ),
+					parseStatement( json )
+			);
+		}
+		catch (Exception e) {
+			throw new RuntimeException( "Error parsing JSON for AwsBucketPolicy", e );
+		}
+	}
+
+	private static List<AwsBucketPolicyStatement> parseStatement(JsonNode json) {
+		if ( !json.has( "Statement" ) ) {
+			return List.of();
+		}
+		return StreamSupport.stream( json.get( "Statement" ).spliterator(), false )
+				.map( edge -> AwsBucketPolicyStatement.fromJson( edge.toString() ) )
+				.collect( Collectors.toList() );
+	}
+}

--- a/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/AwsBucketPolicyStatement.java
+++ b/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/AwsBucketPolicyStatement.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+package com.blazebit.query.connector.aws.s3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Donghwi Kim
+ * @since 1.0.0
+ */
+public record AwsBucketPolicyStatement(
+		String principalJsonValue,
+		String effect,
+		String conditionJsonValue,
+		String resourceJsonValue
+
+) {
+	private static final ObjectMapper MAPPER = ObjectMappers.getInstance();
+
+	public static AwsBucketPolicyStatement fromJson(String payload) {
+		try {
+			JsonNode json = MAPPER.readTree( payload );
+			return new AwsBucketPolicyStatement(
+					json.get( "Principal" ).toString(), json.get( "Effect" ).asText( "" ),
+					json.has( "Condition" ) ? json.get( "Condition" ).toString() : "",
+					json.has( "Resource" ) ? json.get( "Resource" ).toString() : ""
+			);
+		}
+		catch (Exception e) {
+			throw new RuntimeException( "Error parsing JSON for AwsBucketPolicyStatement", e );
+		}
+	}
+}

--- a/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/AwsS3SchemaProvider.java
+++ b/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/AwsS3SchemaProvider.java
@@ -22,6 +22,7 @@ public final class AwsS3SchemaProvider implements QuerySchemaProvider {
 		return Set.of(
 				BucketDataFetcher.INSTANCE,
 				BucketAclFetcher.INSTANCE,
+				BucketPolicyFetcher.INSTANCE,
 				LifecycleRuleFetcher.INSTANCE,
 				LoggingEnabledFetcher.INSTANCE,
 				ObjectLockConfigurationFetcher.INSTANCE,

--- a/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/BucketPolicyFetcher.java
+++ b/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/BucketPolicyFetcher.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+package com.blazebit.query.connector.aws.s3;
+
+import com.blazebit.query.connector.aws.base.AwsConnectorConfig;
+import com.blazebit.query.connector.aws.base.AwsConventionContext;
+import com.blazebit.query.connector.base.DataFormats;
+import com.blazebit.query.spi.DataFetchContext;
+import com.blazebit.query.spi.DataFetcher;
+import com.blazebit.query.spi.DataFetcherException;
+import com.blazebit.query.spi.DataFormat;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.Bucket;
+import software.amazon.awssdk.services.s3.model.GetBucketPolicyRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Donghwi Kim
+ * @since 1.0.0
+ */
+public class BucketPolicyFetcher implements DataFetcher<AwsBucketPolicy>, Serializable {
+
+	public static final BucketPolicyFetcher INSTANCE = new BucketPolicyFetcher();
+
+	private BucketPolicyFetcher() {
+	}
+
+	@Override
+	public List<AwsBucketPolicy> fetch(DataFetchContext context) {
+		try {
+			List<AwsConnectorConfig.Account> accounts = AwsConnectorConfig.ACCOUNT.getAll( context );
+			SdkHttpClient sdkHttpClient = AwsConnectorConfig.HTTP_CLIENT.find( context );
+			List<AwsBucketPolicy> list = new ArrayList<>();
+			for ( AwsConnectorConfig.Account account : accounts ) {
+				for ( Region region : account.getRegions() ) {
+					S3ClientBuilder s3ClientBuilder = S3Client.builder()
+							.region( region )
+							.credentialsProvider( account.getCredentialsProvider() );
+					if ( sdkHttpClient != null ) {
+						s3ClientBuilder.httpClient( sdkHttpClient );
+					}
+					try (S3Client client = s3ClientBuilder.build()) {
+						for ( Bucket bucket : client.listBuckets().buckets() ) {
+							try {
+								var bucketPolicy = client.getBucketPolicy(
+										GetBucketPolicyRequest.builder().bucket( bucket.name() )
+												.build() );
+								list.add( AwsBucketPolicy.fromJson(
+										account.getAccountId(),
+										region.id(),
+										bucket.name(),
+										bucketPolicy.policy()
+								) );
+							}
+							catch (S3Exception e) {
+								if ( Objects.equals( e.awsErrorDetails().errorCode(),
+										"NoSuchBucketPolicy" ) ) {
+									continue;
+								}
+								throw e;
+							}
+						}
+					}
+				}
+			}
+			return list;
+		}
+		catch (Exception e) {
+			throw new DataFetcherException( "Could not fetch bucket policy list", e );
+		}
+	}
+
+	@Override
+	public DataFormat getDataFormat() {
+		return DataFormats.componentMethodConvention( AwsBucketPolicy.class, AwsConventionContext.INSTANCE );
+	}
+}

--- a/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/ObjectMappers.java
+++ b/connector/aws/s3/src/main/java/com/blazebit/query/connector/aws/s3/ObjectMappers.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+package com.blazebit.query.connector.aws.s3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public final class ObjectMappers {
+
+	public static ObjectMapper instance;
+
+	private ObjectMappers() {
+	}
+
+	public static ObjectMapper getInstance() {
+		if ( instance == null ) {
+			instance = new ObjectMapper();
+			instance.findAndRegisterModules();
+		}
+
+		return instance;
+	}
+}

--- a/examples/app/src/main/java/com/blazebit/query/app/Main.java
+++ b/examples/app/src/main/java/com/blazebit/query/app/Main.java
@@ -38,6 +38,7 @@ import com.blazebit.query.connector.aws.rds.AwsDBInstance;
 import com.blazebit.query.connector.aws.route53.AwsHealthCheck;
 import com.blazebit.query.connector.aws.route53.AwsHostedZone;
 import com.blazebit.query.connector.aws.s3.AwsBucketAcl;
+import com.blazebit.query.connector.aws.s3.AwsBucketPolicy;
 import com.blazebit.query.connector.aws.s3.AwsLoggingEnabled;
 import com.blazebit.query.connector.aws.s3.AwsObjectLockConfiguration;
 import com.blazebit.query.connector.aws.s3.AwsPolicyStatus;
@@ -269,6 +270,7 @@ public class Main {
 			// S3
 			queryContextBuilder.registerSchemaObjectAlias( AwsBucket.class, "AwsBucket" );
 			queryContextBuilder.registerSchemaObjectAlias( AwsBucketAcl.class, "AwsBucketAcl" );
+			queryContextBuilder.registerSchemaObjectAlias( AwsBucketPolicy.class, "AwsBucketPolicy" );
 			queryContextBuilder.registerSchemaObjectAlias( AwsLifeCycleRule.class, "AwsLifeCycleRule" );
 			queryContextBuilder.registerSchemaObjectAlias( AwsLoggingEnabled.class, "AwsLoggingEnabled" );
 			queryContextBuilder.registerSchemaObjectAlias( AwsObjectLockConfiguration.class, "AwsObjectLockConfiguration" );
@@ -504,6 +506,12 @@ public class Main {
 		List<Object[]> awsBucketAclResult = awsBucketAclQuery.getResultList();
 		System.out.println("AwsBucketAcl");
 		print(awsBucketAclResult);
+
+		TypedQuery<Object[]> awsBucketPolicyQuery = session.createQuery(
+				"select f.* from AwsBucketPolicy f" );
+		List<Object[]> awsBucketPolicyResult = awsBucketPolicyQuery.getResultList();
+		System.out.println("AwsBucketPolicy");
+		print(awsBucketPolicyResult);
 
 		TypedQuery<Object[]> awsLoggingEnabledQuery = session.createQuery(
 				"select f.* from AwsLoggingEnabled f" );


### PR DESCRIPTION
# Policy (root object)

* **Version** (optional): string.
  Common value: `2012-10-17`.
* **Id** (optional): string.
  Arbitrary identifier for the policy.
* **Statement** (required): either a single **S3PolicyStatement** object or an array of **S3PolicyStatement** objects.

# S3PolicyStatement

* **Sid** (optional): string.
  A statement identifier.
* **Effect** (required): one of `"Allow"` or `"Deny"`.
* **Principal** (optional): **S3Principal**.
* **Action** (optional): string or list of strings.
  One or more action names, e.g. `s3:GetObject` or `["s3:GetObject","s3:ListBucket"]`.
* **Resource** (optional): string or list of strings.
  One or more ARNs, e.g. `arn:aws:s3:::my-bucket/*` or `["arn:aws:s3:::my-bucket","arn:aws:s3:::my-bucket/*"]`.
* **Condition** (optional): **S3Condition**.
  Keyed by condition operator (e.g., `StringEquals`, `Bool`), each mapping to one or more key/value pairs.

# S3Principal

* Either the literal `"*"` (all principals), **or**
* An object whose properties (all optional) narrow who the principal is:

  * **AWS**: string or list of strings.
    AWS principals, e.g. account IDs or ARNs (`"arn:aws:iam::123456789012:root"`).
  * **Service**: string or list of strings.
    AWS services, e.g. `"logs.amazonaws.com"`.
  * **Federated**: string or list of strings.
    Federated identities, e.g. `"cognito-identity.amazonaws.com"`.
  * **CanonicalUser**: string or list of strings.
    Canonical user IDs for S3.

# S3Condition (shape description)

* A map of **operator → condition-keys**.
  Example shape:

  ```
  {
    "<Operator>": {
      "<ConditionKey>": "<string or string[]>"
    }
  }
  ```

  Example:

  ```
  {
    "StringEquals": { "s3:prefix": ["home/", "home/*"] },
    "Bool": { "aws:SecureTransport": "true" }
  }
  ```