### PR TITLE
Fix Azure Vault data fetcher to match by subscription ID instead of tenant ID

### DIFF
--- a/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/VaultDataFetcher.java
+++ b/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/VaultDataFetcher.java
@@ -37,7 +37,7 @@ public class VaultDataFetcher implements DataFetcher<AzureResourceVault>, Serial
 					AzureResourceManagerResourceGroup.class );
 			for ( AzureResourceManager resourceManager : resourceManagers ) {
 				for ( AzureResourceManagerResourceGroup resourceGroup : resourceGroups ) {
-					if ( resourceManager.tenantId().equals( resourceGroup.getTenantId() ) ) {
+					if ( resourceManager.subscriptionId().equals( resourceGroup.getSubscriptionId() ) ) {
 						for ( Vault vault : resourceManager.vaults()
 								.listByResourceGroup( resourceGroup.getResourceGroupName() ) ) {
 							list.add( new AzureResourceVault(


### PR DESCRIPTION
 ## Summary
  - Fix incorrect matching logic in `VaultDataFetcher` that was comparing tenant IDs instead of subscription IDs when iterating through resource groups

  ## Details
  The vault data fetcher was incorrectly matching resource managers to resource groups by tenant ID. Since multiple subscriptions can exist within the same tenant, this caused vaults to be fetched for incorrect resource groups.

  This change corrects the logic to match by subscription ID, ensuring vaults are only fetched for resource groups within the same subscription.