### PR TITLE
Remove automaticCopilotCodeReviewEnabled from GitHub GraphQL connector

### DIFF
--- a/connector/github-graphql/src/main/java/com/blazebit/query/connector/github/graphql/GitHubGraphQlClient.java
+++ b/connector/github-graphql/src/main/java/com/blazebit/query/connector/github/graphql/GitHubGraphQlClient.java
@@ -147,10 +147,13 @@ public class GitHubGraphQlClient {
 								nodes {
 									type
 									parameters {
+										... on CopilotCodeReviewParameters {
+											reviewDraftPullRequests
+											reviewOnPush
+										}
 										... on PullRequestParameters {
 											requireCodeOwnerReview
 											requiredApprovingReviewCount
-											automaticCopilotCodeReviewEnabled
 											dismissStaleReviewsOnPush
 											requireLastPushApproval
 											requiredReviewThreadResolution
@@ -311,10 +314,13 @@ public class GitHubGraphQlClient {
 								nodes {
 									type
 									parameters {
+										... on CopilotCodeReviewParameters {
+											reviewDraftPullRequests
+											reviewOnPush
+										}
 										... on PullRequestParameters {
 											requireCodeOwnerReview
 											requiredApprovingReviewCount
-											automaticCopilotCodeReviewEnabled
 											dismissStaleReviewsOnPush
 											requireLastPushApproval
 											requiredReviewThreadResolution

--- a/connector/github-graphql/src/main/java/com/blazebit/query/connector/github/graphql/GitHubRule.java
+++ b/connector/github-graphql/src/main/java/com/blazebit/query/connector/github/graphql/GitHubRule.java
@@ -18,7 +18,8 @@ import java.util.stream.StreamSupport;
 public record GitHubRule(
 		String type,
 		GitHubRulePullRequestParameters pullRequestParameters,
-		GitHubRuleRequiredStatusChecksParameters requiredStatusChecksParameters
+		GitHubRuleRequiredStatusChecksParameters requiredStatusChecksParameters,
+		GitHubRuleCopilotCodeReviewParameters copilotCodeReviewParameters
 ) {
 	private static final ObjectMapper MAPPER = ObjectMappers.getInstance();
 
@@ -30,7 +31,8 @@ public record GitHubRule(
 			return new GitHubRule(
 					ruleType,
 					GitHubRulePullRequestParameters.parseRuleParameters( json.path( "parameters" ) ),
-					GitHubRuleRequiredStatusChecksParameters.parseRequiredStatusChecksParameters( json.path( "parameters" ) )
+					GitHubRuleRequiredStatusChecksParameters.parseRequiredStatusChecksParameters( json.path( "parameters" ) ),
+					GitHubRuleCopilotCodeReviewParameters.parseCopilotCodeReviewParameters( json.path( "parameters" ) )
 			);
 		} catch (Exception e) {
 			throw new RuntimeException("Error parsing JSON for GithubRule", e);

--- a/connector/github-graphql/src/main/java/com/blazebit/query/connector/github/graphql/GitHubRuleCopilotCodeReviewParameters.java
+++ b/connector/github-graphql/src/main/java/com/blazebit/query/connector/github/graphql/GitHubRuleCopilotCodeReviewParameters.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+package com.blazebit.query.connector.github.graphql;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * @author Donghwi Kim
+ * @since 1.0.28
+ */
+public record GitHubRuleCopilotCodeReviewParameters(
+		boolean reviewDraftPullRequests,
+		boolean reviewOnPush
+) {
+	public static GitHubRuleCopilotCodeReviewParameters parseCopilotCodeReviewParameters(JsonNode json) {
+		if (json.isMissingNode() || json.isNull()) {
+			return null;
+		}
+
+		return new GitHubRuleCopilotCodeReviewParameters(
+				json.path("reviewDraftPullRequests").asBoolean(false),
+				json.path("reviewOnPush").asBoolean(false)
+		);
+	}
+}

--- a/connector/github-graphql/src/main/java/com/blazebit/query/connector/github/graphql/GitHubRulePullRequestParameters.java
+++ b/connector/github-graphql/src/main/java/com/blazebit/query/connector/github/graphql/GitHubRulePullRequestParameters.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 public record GitHubRulePullRequestParameters(
 		boolean requireCodeOwnerReview,
 		int requiredApprovingReviewCount,
-		boolean automaticCopilotCodeReviewEnabled,
 		boolean dismissStaleReviewsOnPush,
 		boolean requireLastPushApproval,
 		boolean requiredReviewThreadResolution
@@ -39,7 +38,6 @@ public record GitHubRulePullRequestParameters(
 		return new GitHubRulePullRequestParameters(
 				json.path("requireCodeOwnerReview").asBoolean(false),
 				json.path("requiredApprovingReviewCount").asInt(0),
-				json.path("automaticCopilotCodeReviewEnabled").asBoolean(false),
 				json.path("dismissStaleReviewsOnPush").asBoolean(false),
 				json.path("requireLastPushApproval").asBoolean(false),
 				json.path("requiredReviewThreadResolution").asBoolean(false)

--- a/connector/github-graphql/src/test/java/GitHubGraphQlTestObjects.java
+++ b/connector/github-graphql/src/test/java/GitHubGraphQlTestObjects.java
@@ -54,11 +54,10 @@ public class GitHubGraphQlTestObjects {
 						0,
 						false,
 						false,
-						false,
 						false
 				);
 
-		return new GitHubRule("PULL_REQUEST", pullRequestParameters, null);
+		return new GitHubRule("PULL_REQUEST", pullRequestParameters, null, null);
 	}
 
 	public static GitHubRepository repository() {


### PR DESCRIPTION
- Field `automaticCopilotCodeReviewEnabled`  was removed from github api https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2025-12-05 
- New type `CopilotCodeReviewParameters` is added to github api
https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2025-09-16
