### PR TITLE
Skip FileStorage accounts in BlobServicePropertiesDataFetcher

### DIFF
--- a/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/BlobServicePropertiesDataFetcher.java
+++ b/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/BlobServicePropertiesDataFetcher.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.storage.models.BlobServiceProperties;
+import com.azure.resourcemanager.storage.models.Kind;
 import com.blazebit.query.connector.base.DataFormats;
 import com.blazebit.query.spi.DataFetchContext;
 import com.blazebit.query.spi.DataFetcher;
@@ -36,7 +37,8 @@ public class BlobServicePropertiesDataFetcher implements DataFetcher<AzureResour
 			for ( AzureResourceManager resourceManager : resourceManagers ) {
 				for ( AzureResourceStorageAccount storageAccount : context.getSession()
 						.getOrFetch( AzureResourceStorageAccount.class ) ) {
-					if ( resourceManager.subscriptionId().equals( storageAccount.getSubscriptionId() ) ) {
+					if ( resourceManager.subscriptionId().equals( storageAccount.getSubscriptionId() )
+							&& storageAccount.getPayload().kind() != Kind.FILE_STORAGE ) {
 						BlobServiceProperties blobServiceProperties = resourceManager.storageBlobServices()
 								.getServicePropertiesAsync(
 										storageAccount.getResourceGroupName(),


### PR DESCRIPTION
FileStorage accounts (premium file-only storage) do not support blob storage and return a 400 error with code FeatureNotSupportedForAccount. This change filters out these accounts by checking the storage account kind before attempting to fetch blob service properties.