### PR TITLE
Skip LTR clone servers in PostgreSQL Flexible Server data fetchers

### DIFF
--- a/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/PostgreSqlFlexibleServerBackupDataFetcher.java
+++ b/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/PostgreSqlFlexibleServerBackupDataFetcher.java
@@ -7,6 +7,7 @@ package com.blazebit.query.connector.azure.resourcemanager;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.Server;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.ServerBackup;
+import com.azure.resourcemanager.postgresqlflexibleserver.models.ServerState;
 import com.blazebit.query.connector.base.DataFormats;
 import com.blazebit.query.spi.DataFetchContext;
 import com.blazebit.query.spi.DataFetcher;
@@ -35,6 +36,10 @@ public class PostgreSqlFlexibleServerBackupDataFetcher implements DataFetcher<Az
 			List<AzureResourcePostgreSqlFlexibleServerBackup> list = new ArrayList<>();
 			for ( AzureResourceManagerPostgreSqlManager resourceManager : postgreSqlResourceManagers ) {
 				for ( Server postgreSqlFlexibleServer : resourceManager.getManager().servers().list() ) {
+					if ( !postgreSqlFlexibleServer.state().equals( ServerState.READY )
+							&& postgreSqlFlexibleServer.name().toLowerCase().contains( "ltrclone" ) ) {
+						continue;
+					}
 					try {
 						for ( ServerBackup postgreSqlFlexibleServerBackup : resourceManager.getManager().backups().listByServer( postgreSqlFlexibleServer.resourceGroupName(), postgreSqlFlexibleServer.name() ) ) {
 							list.add( new AzureResourcePostgreSqlFlexibleServerBackup(

--- a/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/PostgreSqlFlexibleServerDataFetcher.java
+++ b/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/PostgreSqlFlexibleServerDataFetcher.java
@@ -5,6 +5,7 @@
 package com.blazebit.query.connector.azure.resourcemanager;
 
 import com.azure.resourcemanager.postgresqlflexibleserver.models.Server;
+import com.azure.resourcemanager.postgresqlflexibleserver.models.ServerState;
 import com.blazebit.query.connector.base.DataFormats;
 import com.blazebit.query.spi.DataFetchContext;
 import com.blazebit.query.spi.DataFetcher;
@@ -34,6 +35,10 @@ public class PostgreSqlFlexibleServerDataFetcher implements DataFetcher<AzureRes
 			List<AzureResourcePostgreSqlFlexibleServer> list = new ArrayList<>();
 			for ( AzureResourceManagerPostgreSqlManager resourceManager : postgreSqlResourceManagers ) {
 				for ( Server postgreSqlFlexibleServer : resourceManager.getManager().servers().list() ) {
+					if ( !postgreSqlFlexibleServer.state().equals( ServerState.READY )
+							&& postgreSqlFlexibleServer.name().toLowerCase().contains( "ltrclone" ) ) {
+						continue;
+					}
 					list.add( new AzureResourcePostgreSqlFlexibleServer(
 							resourceManager.getTenantId(),
 							postgreSqlFlexibleServer.id(),

--- a/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/PostgreSqlFlexibleServerWithParametersDataFetcher.java
+++ b/connector/azure/resourcemanager/src/main/java/com/blazebit/query/connector/azure/resourcemanager/PostgreSqlFlexibleServerWithParametersDataFetcher.java
@@ -5,6 +5,7 @@
 package com.blazebit.query.connector.azure.resourcemanager;
 
 import com.azure.resourcemanager.postgresqlflexibleserver.models.Server;
+import com.azure.resourcemanager.postgresqlflexibleserver.models.ServerState;
 import com.blazebit.query.connector.base.DataFormats;
 import com.blazebit.query.spi.DataFetchContext;
 import com.blazebit.query.spi.DataFetcher;
@@ -40,6 +41,10 @@ public class PostgreSqlFlexibleServerWithParametersDataFetcher implements DataFe
 		if (!parametersToFetch.isEmpty()) {
 			for (AzureResourceManagerPostgreSqlManager resourceManager : postgreSqlResourceManagers) {
 			for (Server postgreSqlFlexibleServer : resourceManager.getManager().servers().list()) {
+				if ( !postgreSqlFlexibleServer.state().equals( ServerState.READY )
+						&& postgreSqlFlexibleServer.name().toLowerCase().contains( "ltrclone" ) ) {
+					continue;
+				}
 				Map<String, String> serverParameters = new HashMap<>();
 
 				for (String parameterName : parametersToFetch) {


### PR DESCRIPTION
LTR clone references may not exist as actual servers, causing errors when fetching data. This adds an upfront check to skip servers with names containing "ltrclone" in all three PostgreSQL Flexible Server data fetchers.