### PR TITLE
Upgrade Hibernate from 6.5.2 to 7.2.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ jakarta-persistence-api = "3.0.0"
 junit-jupiter = "5.11.3"
 assertj = "3.26.3"
 h2 = "2.2.224"
-hibernate = "6.5.2.Final"
+hibernate = "7.2.6.Final"
 
 [libraries]
 calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }


### PR DESCRIPTION
## Summary
- Bumps Hibernate ORM from 6.5.2.Final to 7.0.2.Final in `libs.versions.toml`

## Test plan
- [ ] Verify project compiles with the new Hibernate version
- [ ] Run existing integration tests that use Hibernate (e.g. JPA connector tests)
- [ ] Check for any breaking API changes between Hibernate 6.x and 7.x