### PR TITLE
Upgrade Hibernate from 6.5.2 to 7.2.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ jakarta-persistence-api = "3.0.0"
 junit-jupiter = "5.11.3"
 assertj = "3.26.3"
 h2 = "2.2.224"
-hibernate = "6.5.2.Final"
+hibernate = "7.2.6.Final"
 
 [libraries]
 calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }


### PR DESCRIPTION
## Summary
- Bumps Hibernate ORM from 6.5.2.Final to 7.2.6.Final (latest stable)

## Test plan
- [x] Full build passes: `./gradlew clean build`
- Only used in `examples/app` module via standard JPA annotations + `SessionFactory.inTransaction()`
- No source-level incompatibilities found